### PR TITLE
Add theme toggle and dark mode to MyAccount page

### DIFF
--- a/src/app/myaccount/page.tsx
+++ b/src/app/myaccount/page.tsx
@@ -18,11 +18,27 @@ import {
   NavSubItemGroup,
 } from "@fluentui/react-nav-preview";
 import { PersonCircle32Regular } from "@fluentui/react-icons";
-import { DrawerProps, Tooltip } from "@fluentui/react-components";
+import { Button, DrawerProps, Tooltip } from "@fluentui/react-components";
 import { useTheme } from "@/theme/ThemeProvider";
 import styles from "./styles.module.css";
 
 type DrawerType = Required<DrawerProps>["type"];
+
+// Theme toggle component for light/dark mode switching
+const ThemeToggle = () => {
+  const { themeMode, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      appearance="subtle"
+      icon={<i className={`ti ti-${themeMode === "light" ? "moon" : "sun"}`} />}
+      onClick={toggleTheme}
+      className={styles.themeToggle}
+    >
+      {themeMode === "light" ? "Dark mode" : "Light mode"}
+    </Button>
+  );
+};
 
 export default function MyAccountPage() {
   const [isOpen, setIsOpen] = React.useState(true);
@@ -30,9 +46,10 @@ export default function MyAccountPage() {
   const { themeMode } = useTheme();
 
   const isDark = themeMode === "dark";
+  const darkClass = isDark ? styles.darkContainer : "";
 
   return (
-    <div className={styles.root}>
+    <div className={`${styles.root} ${darkClass}`}>
       <NavDrawer
         defaultSelectedValue="2"
         defaultSelectedCategoryValue=""
@@ -139,11 +156,16 @@ export default function MyAccountPage() {
         </NavDrawerBody>
       </NavDrawer>
 
-      <div className={styles.content}>
+      <div className={`${styles.content} ${darkClass}`}>
         <div className={styles.header}>
-          <Tooltip content="Toggle navigation pane" relationship="label">
-            <Hamburger onClick={() => setIsOpen(!isOpen)} />
-          </Tooltip>
+          <div className={styles.headerLeft}>
+            <Tooltip content="Toggle navigation pane" relationship="label">
+              <Hamburger onClick={() => setIsOpen(!isOpen)} />
+            </Tooltip>
+          </div>
+          <div className={styles.headerRight}>
+            <ThemeToggle />
+          </div>
         </div>
 
         <div className={styles.mainContent}>
@@ -306,6 +328,14 @@ export default function MyAccountPage() {
           </section>
         </div>
       </div>
+      <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css"
+      />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap"
+        rel="stylesheet"
+      />
     </div>
   );
 }

--- a/src/app/myaccount/page.tsx
+++ b/src/app/myaccount/page.tsx
@@ -210,25 +210,24 @@ export default function MyAccountPage() {
             <h2 className={styles.sectionTitle}>Set up your account</h2>
             <div className={styles.wideCardGrid}>
               <CardWide
-                buttonText="Create a Passkey"
                 titleText="Set up multi-factor authentication"
                 bodyText="Create a passkey, Microsoft authenticator, etc. or ............."
                 imageUrl="https://cdn.builder.io/api/v1/image/assets/375626aef9734fa5a388227cc2b6eab1/ab9a3d3cd1d5ece12c84f5d1608dae18093a29ed?placeholderIfAbsent=true"
                 imageAlt="Set up multi-factor authentication"
                 variant="info"
-                imagePosition="left"
-                showButton={true}
+                imagePosition="right"
+                showBarIcon={false}
+                showButton={false}
               />
               <CardWide
-                buttonText="Create a Passkey"
                 titleText="Set up multi-factor authentication"
                 bodyText="Create a passkey, Microsoft authenticator, etc. or ............."
                 imageUrl="https://cdn.builder.io/api/v1/image/assets/375626aef9734fa5a388227cc2b6eab1/5a313acb1c45f3203449f07614b2e01c5379430e?placeholderIfAbsent=true"
                 imageAlt="Set up multi-factor authentication"
                 variant="info"
-                imagePosition="left"
-                showBarIcon={true}
-                showButton={true}
+                imagePosition="right"
+                showBarIcon={false}
+                showButton={false}
               />
             </div>
           </section>

--- a/src/app/myaccount/page.tsx
+++ b/src/app/myaccount/page.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import CardSquare from "@/components/CardSquare";
+import { CardWide } from "@/components";
 import {
   AppItem,
   Hamburger,
@@ -207,18 +208,27 @@ export default function MyAccountPage() {
 
           <section className={styles.section}>
             <h2 className={styles.sectionTitle}>Set up your account</h2>
-            <div className={styles.cardGrid}>
-              <CardSquare
-                imageUrl="https://cdn.builder.io/api/v1/image/assets/375626aef9734fa5a388227cc2b6eab1/c95e44fab5a417d6436335305c98bd048da991de?placeholderIfAbsent=true"
-                imageAlt="Setup"
-                variant="setup"
-                className={styles.setupCard}
+            <div className={styles.wideCardGrid}>
+              <CardWide
+                buttonText="Create a Passkey"
+                titleText="Set up multi-factor authentication"
+                bodyText="Create a passkey, Microsoft authenticator, etc. or ............."
+                imageUrl="https://cdn.builder.io/api/v1/image/assets/375626aef9734fa5a388227cc2b6eab1/ab9a3d3cd1d5ece12c84f5d1608dae18093a29ed?placeholderIfAbsent=true"
+                imageAlt="Set up multi-factor authentication"
+                variant="info"
+                imagePosition="left"
+                showButton={true}
               />
-              <CardSquare
+              <CardWide
+                buttonText="Create a Passkey"
+                titleText="Set up multi-factor authentication"
+                bodyText="Create a passkey, Microsoft authenticator, etc. or ............."
                 imageUrl="https://cdn.builder.io/api/v1/image/assets/375626aef9734fa5a388227cc2b6eab1/5a313acb1c45f3203449f07614b2e01c5379430e?placeholderIfAbsent=true"
-                imageAlt="Profile"
-                variant="setup"
-                className={styles.setupCard}
+                imageAlt="Set up multi-factor authentication"
+                variant="info"
+                imagePosition="left"
+                showBarIcon={true}
+                showButton={true}
               />
             </div>
           </section>

--- a/src/app/myaccount/styles.module.css
+++ b/src/app/myaccount/styles.module.css
@@ -18,6 +18,19 @@
 
 .header {
   margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
 }
 
 .mainContent {
@@ -250,6 +263,60 @@
   font-size: 14px;
   font-weight: 600;
   color: #242424;
+}
+
+/* Theme toggle button */
+.themeToggle {
+  margin-right: 8px;
+}
+
+/* Dark theme support */
+.darkContainer {
+  background-color: #1f1f1f;
+  color: #ffffff;
+}
+
+.darkContainer .welcomeTitle,
+.darkContainer .sectionTitle {
+  color: #e1e1e1;
+}
+
+.darkContainer .profileName,
+.darkContainer .nameHeader {
+  color: #e1e1e1;
+}
+
+.darkContainer .infoItem {
+  color: #c8c8c8;
+}
+
+.darkContainer .editLink {
+  color: #4ea0ff;
+}
+
+.darkContainer .setupCard,
+.darkContainer .securityCard,
+.darkContainer .discoveryCard,
+.darkContainer .appCard {
+  background-color: #292929;
+  box-shadow:
+    0px 0.3px 0.9px rgba(255, 255, 255, 0.05),
+    0px 1.6px 3.6px rgba(255, 255, 255, 0.07);
+}
+
+.darkContainer .cardTitle,
+.darkContainer .appName {
+  color: #e1e1e1;
+}
+
+.darkContainer .cardDescription {
+  color: #c8c8c8;
+}
+
+.darkContainer .manageButton {
+  background-color: #2b2b2b;
+  border-color: #444444;
+  color: #e1e1e1;
 }
 
 @media (max-width: 991px) {

--- a/src/app/myaccount/styles.module.css
+++ b/src/app/myaccount/styles.module.css
@@ -139,6 +139,18 @@
   flex-wrap: wrap;
 }
 
+.wideCardGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 100%;
+}
+
+.wideCardGrid > * {
+  flex: 1;
+  min-width: 410px;
+}
+
 .setupCard {
   flex: 1;
   min-width: 240px;
@@ -333,8 +345,14 @@
     width: 100%;
   }
 
-  .cardGrid {
+  .cardGrid,
+  .wideCardGrid {
     flex-direction: column;
+  }
+
+  .wideCardGrid > * {
+    width: 100%;
+    min-width: 100%;
   }
 
   .setupCard,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export { default as Tile } from "./Tile";
+export { CardWide } from "./CardWide";


### PR DESCRIPTION
- Added theme toggle button to header
- Implemented dark mode styles for MyAccount page
- Replaced setup cards with wide card variants
- Added responsive styles for wide cards
- Updated component exports

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=pixel-haven&projectId=e0e3890f4d8f4eacb6bc1444e12c83ed)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e0e3890f4d8f4eacb6bc1444e12c83ed</projectId>-->